### PR TITLE
Team summary fixes

### DIFF
--- a/src/monster_instance.ts
+++ b/src/monster_instance.ts
@@ -28,7 +28,7 @@ const LatentAtk = new Map<Latent, number>([
 
 const LatentRcv = new Map<Latent, number>([
   [Latent.RCV, 0.1],
-  [Latent.HP_PLUS, 0.3],
+  [Latent.RCV_PLUS, 0.3],
   [Latent.ALL_STATS, 0.2],
 ]);
 

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -1469,7 +1469,7 @@ class TeamPane {
       Awakening.RESIST_CLOUD,
       Awakening.RESIST_TAPE,
       Awakening.OE_FIRE,
-      Awakening.OE_WOOD,
+      Awakening.OE_WATER,
       Awakening.OE_WOOD,
       Awakening.OE_LIGHT,
       Awakening.OE_DARK,

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -1137,7 +1137,7 @@ class LatentEditor {
       }
       remover.style.display = ''
       const latent = activeLatents[i];
-      const isSuper = latent > 11;
+      const isSuper = latent >= 11;
       totalLatents += isSuper ? 2 : 1;
       let offsetWidth, offsetHeight;
       const x = isSuper ? (latent - 11) % 5 : latent;


### PR DESCRIPTION
- RCV+ latents did nothing, and HP+ latents increased RCV
- Wood OEs showed twice on the team stats' awakening totals
- AllStat latents would show as taking 1 slot rather than 2 when added to a monster in the editor, and would display as nothing